### PR TITLE
fix: make hal-mvn-jdk image usable by other runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,14 @@ docker push quay.io/halkyonio/spring-boot-offline-maven
 ## Hal Maven JDK8 image
 
 This image extends the maven jdk image `maven:3.6.2-jdk-8-slim`, keeps downloaded dependencies in `/tmp/artefacts` and uses 
-shell scripts to build and run maven java projects: 
-
-- `mvn -f /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/pom.xml ${MAVEN_ARGS} package -Dmaven.repo.local=/tmp/artefacts`
-- `java -cp . -jar /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/target/*.jar`
+shell scripts to [build](hal-mvn-jdk/build) and [run](hal-mvn-jdk/run) maven java projects: 
 
 ENV Vars available:
 
 - `CONTEXTPATH`: path to access the directory of the maven project
 - `MODULEDIRNAME`: Name of the maven module directory when your project is designed as a maven multi-modules structure
 - `MAVEN_ARGS`: arguments to pass to the Maven command (e.g. -X)
+- `JARPATTERN`: pattern (e.g. `*` or `*-runner`) allowing the build command to identify which jar is the executable binary
 
 To build the image
 ```bash

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ docker push quay.io/halkyonio/spring-boot-offline-maven
 
 ## Hal Maven JDK8 image
 
-This image extends the maven jdk image `maven:3.6.2-jdk-8-slim`, includes an [offline
-maven repo](maven-offline-repo) and needed bash scripts to perform: 
+This image extends the maven jdk image `maven:3.6.2-jdk-8-slim`, keeps downloaded dependencies in `/tmp/artefacts` and uses 
+shell scripts to build and run maven java projects: 
 
 - `mvn -f /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/pom.xml ${MAVEN_ARGS} package -Dmaven.repo.local=/tmp/artefacts`
 - `java -cp . -jar /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/target/*.jar`

--- a/hal-mvn-jdk/Dockerfile
+++ b/hal-mvn-jdk/Dockerfile
@@ -1,11 +1,11 @@
-FROM spring-boot-offline-maven
+FROM maven:3.6.2-jdk-8-slim
 
 ADD build /usr/local/bin/
 ADD run /usr/local/bin/
-RUN mkdir /deployments && \
-    chown 1001:0 /deployments && \
-    chmod a+x /deployments
-RUN chmod -R 777 /tmp/artefacts && \
-    chown -R 1001:0 /tmp/artefacts
+
+RUN mkdir -p /tmp/artefacts && chmod -R 777 /tmp/artefacts && chown -R 1001:0 /tmp/artefacts
+
+RUN mkdir /deployments && chown 1001:0 /deployments && chmod a+x /deployments
+
 RUN chmod +x /usr/local/bin/run && chmod +x /usr/local/bin/build
 CMD ["/usr/local/bin/run"]

--- a/hal-mvn-jdk/build
+++ b/hal-mvn-jdk/build
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-mvn -f /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/pom.xml ${MAVEN_ARGS} package -DskipTests -DskipITs -Dmaven.repo.local=/tmp/artefacts && cp /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/target/*.jar /deployments/app.jar
+mvn -f /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/pom.xml ${MAVEN_ARGS} package -DskipTests -DskipITs -Dmaven.repo.local=/tmp/artefacts && cp /usr/src/${CONTEXTPATH}/${MODULEDIRNAME}/target/${JARPATTERN}.jar /deployments/app.jar

--- a/hal-mvn-jdk/run
+++ b/hal-mvn-jdk/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 java -XX:+UseParallelOldGC \
      -XX:MinHeapFreeRatio=10 \

--- a/maven-offline-repo/Dockerfile
+++ b/maven-offline-repo/Dockerfile
@@ -1,10 +1,8 @@
-FROM maven:3.6.2-jdk-8-slim
+FROM hal-maven-jdk
 
 USER root
 
 ADD pom.xml pom.xml
-
-RUN mkdir -p /tmp/artefacts
 
 # Problem with the official maven plugin --> Not all maven plugins downloaded !!
 # RUN mvn dependency:go-offline -f pom.xml -Dmaven.repo.local=/tmp/artefacts


### PR DESCRIPTION
This accomplished via 2 means: first, make the image bundling some SB dependencies
depend on this one instead of the reverse and second, parameterize the build
command so that it retrieves a JARPATTERN env var to identify which jar needs to
be run.