### PR TITLE
fix: give running application a chance to stop gracefully

### DIFF
--- a/supervisord/conf/supervisord.tmpl
+++ b/supervisord/conf/supervisord.tmpl
@@ -4,6 +4,8 @@ autostart = {{.AutoStart}}
 stdout_logfile = /dev/stdout
 stderr_logfile = /dev/stdout
 stdout_events_enabled = true
+stopsignal = TERM
+stopwaitsecs = 5
 
 {{end}}{{end}}[inet_http_server]
 port=localhost:9001


### PR DESCRIPTION
When `hal` asks the running application to stop, it does so by asking `supervisord` to `ctl stop run`. The `supervisord` configuration doesn't have a `stopsignal` configuration, so `supervisord` proceeds to directly sending `SIGKILL`. It's a good practice that applications react to `SIGTERM` and perform graceful shutdown. This commit therefore configures `supervisord` to first send `SIGTERM` and only if the application is still running after 5 seconds, proceed with `SIGKILL`.